### PR TITLE
chore: set up CI, .gitignore, and pre-commit configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: Python Tests and Linting
+
+on:
+  push:
+    branches: [main, feature/*]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          
+      - name: Lint - Black
+        run: black --check .
+        
+      - name: Lint - isort
+        run: isort --check .
+        
+      - name: Lint - flake8
+        run: flake8 .
+        
+      - name: Test with coverage
+        run: |
+          # מריצים pytest פעם אחת, עם coverage
+          coverage run -m pytest --maxfail=3 --disable-warnings -v
+          coverage report -m

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,17 @@
+####################
+# OS Specific
+####################
+# macOS
+.DS_Store
+
+# Windows
+Thumbs.db
+ehThumbs.db
+Desktop.ini
+
+####################
+# Python
+####################
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -26,12 +40,6 @@ share/python-wheels/
 *.egg
 MANIFEST
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
@@ -55,13 +63,11 @@ cover/
 *.mo
 *.pot
 
-# Django stuff:
+# Django/Flask stuff:
 *.log
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
-
-# Flask stuff:
 instance/
 .webassets-cache
 
@@ -82,51 +88,6 @@ target/
 profile_default/
 ipython_config.py
 
-# pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# UV
-#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#uv.lock
-
-# poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
-
-# pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
-#pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
-#   in version control.
-#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
-.pdm.toml
-.pdm-python
-.pdm-build/
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
-
 # Environments
 .env
 .venv
@@ -136,36 +97,44 @@ ENV/
 env.bak/
 venv.bak/
 
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
-# mypy
+# Pyre / Mypy / pytype
 .mypy_cache/
 .dmypy.json
 dmypy.json
-
-# Pyre type checker
 .pyre/
-
-# pytype static type analyzer
 .pytype/
 
 # Cython debug symbols
 cython_debug/
 
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+####################
+# IDEs / Editors
+####################
+# VSCode
+.vscode/
+
+# PyCharm / JetBrains
+.idea/
+
+# Spyder
+.spyderproject
+.spyproject
+
+# Rope
+.ropeproject
+
+####################
+# Misc
+####################
+# For a library or package, you might want to ignore this file
+.python-version
+
+# PyInstaller
+*.manifest
+*.spec
+
+# mkdocs
+/site
 
 # PyPI configuration file
 .pypirc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        
+  - repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+      - id: black
+        
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.isort]
+profile = "black"
+
+[tool.black]
+line-length = 88

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,23 @@
+# Flask and extensions
+Flask>=2.0.0,<3.0.0
+flask-cors>=3.0.10,<4.0.0
+flask-httpauth>=4.5.0,<5.0.0
+
+# Security
+PyJWT>=2.3.0,<3.0.0
+bcrypt>=3.2.0,<4.0.0
+
+# Utilities
+python-dotenv>=0.19.0,<1.0.0
+uuid>=1.30,<2.0.0
+pydantic>=1.9.0,<2.0.0
+
+# Development and Testing
+pytest>=7.0.0,<8.0.0
+pytest-cov>=3.0.0,<4.0.0
+black>=23.1.0,<24.0.0
+flake8>=6.1.0,<7.0.0
+isort>=5.12.0,<6.0.0
+
+# Production
+gunicorn>=20.1.0,<21.0.0


### PR DESCRIPTION
- Add .gitignore with Python, macOS, Windows, and IDE ignores
- Add .pre-commit-config.yaml for Black, isort, and Flake8 hooks
- Add pyproject.toml for unified Black/isort configuration (line-length=88)
- Add .flake8 to ignore E203 and W503 (consistent with Black)
- Add ci.yaml (GitHub Actions) for linting, testing, and coverage
- Update requirements.txt with pinned versions matching pre-commit config